### PR TITLE
Update README.md to show an example of Logging out

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,38 @@ const MyProtectedPage = withAdalLoginApi(MyPage, () => <Loading />, (error) => <
 />
 
 ```
+# Logging Out
+
+The AuthenticationContext object (authContext) has a built in function (logOut) to log out of a session. This function redirects user to the logout endpoint.
+After logout, the user will be redirected to the postLogoutRedirectUri if it was added as a property on the config object.
+The following code shows an example of how to create a Log Out dropdown in a NavBar
+
+```javascript
+import React from 'react';
+import { Navbar, Dropdown, DropdownMenu, DropdownItem } from 'reactstrap';
+import { authContext } from '../adalConfig';
+
+...
+
+  render() {
+    return (
+      <header>
+        <NavBar>
+          ...
+            <Dropdown>
+              <DropdownMenu>
+                <DropdownItem onClick={() => authContext.logOut()}>
+                  Logout
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+          ...
+        </NavBar>
+      </header>
+    );
+  }
+```
+
 # changelog
 ```
 v0.4.24


### PR DESCRIPTION
The current documentation shows examples of construction the config object and using AuthenticationContext. I think that in order for the library's documentation to be more useful at a glance to a new user, it should also show an example of how to log out of the session created by react-adal.

This would complete the full lifecycle of an application that uses authentication (Logging In -> Logged In State -> Log Out -> Redirect)

In order to achieve this goal, I have added a sub-heading to the README.md that uses the example of a DropdownItem in a NavBar to show how the logOut function of AuthenticationContext could be used.
I chose the Dropdown example since the typical placement of a logout button would be within either a NavBar or nested within a Dropdown in a NavBar and this would allow a user to grasp the context of logOut usage without having to delve deep into the source.